### PR TITLE
Change resolution when isolating component.

### DIFF
--- a/package.json
+++ b/package.json
@@ -54,7 +54,13 @@
         "bit.envs/compilers/react-typescript@3.1.51": {
           "rawConfig": {
               "tsconfig": {
-                "compilerOptions": {},
+                "compilerOptions": {
+                "baseUrl": "./",
+                "paths": {
+                  "@material-ui/core/styles/createMuiTheme": [
+                    "./node_modules/@bit/krislao.playground-wc.types-palette"
+                  ]
+                },
                 "include": [
                   "./**/*",
                   "node_modules/@bit/krislao.playground-wc.types-palette"


### PR DESCRIPTION
Typescript doesn't resolve the additional types. When you import from `node_modules` types are resolved from `@materialui/core` and from your sources specified in the `tsconfig.json` file. There is no way for typescript to find this unless directed somehow. The type definition isn't included in the source.